### PR TITLE
Add more logging to the log file

### DIFF
--- a/mediawiki.lrdevplugin/MediaWikiApi.lua
+++ b/mediawiki.lrdevplugin/MediaWikiApi.lua
@@ -29,10 +29,12 @@ local MediaWikiApi = {
 }
 
 function MediaWikiApi.httpError(status)
+	MediaWikiUtils.tracef('HttpError: Received HTTP status %s.', status)
 	LrErrors.throwUserError(LOC("$$$/LrMediaWiki/Api/HttpError=Received HTTP status ^1.", status))
 end
 
 function MediaWikiApi.mediaWikiError(code, info)
+	MediaWikiUtils.tracef('MediaWikiError: The MediaWiki error %s occured: %s.', code, info)
 	LrErrors.throwUserError(LOC("$$$/LrMediaWiki/Api/MediaWikiError=The MediaWiki error ^1 occured: ^2", code, info))
 end
 
@@ -106,6 +108,7 @@ function MediaWikiApi.performHttpRequest(path, arguments, requestHeaders, post)
 	MediaWikiUtils.trace(resultHeaders.status);
 
 	if not resultHeaders.status then
+		MediaWikiUtils.trace('NoConnection: No network connection.');
 		LrErrors.throwUserError(LOC("$$$/LrMediaWiki/Api/NoConnection=No network connection."))
 	elseif resultHeaders.status ~= 200 then
 		MediaWikiApi.httpError(resultHeaders.status)

--- a/mediawiki.lrdevplugin/MediaWikiInterface.lua
+++ b/mediawiki.lrdevplugin/MediaWikiInterface.lua
@@ -179,6 +179,7 @@ MediaWikiInterface.uploadFile = function(filePath, description, hasDescription, 
 	end
 	local uploadResult = MediaWikiApi.upload(targetFileName, filePath, description, comment, ignorewarnings)
 	if uploadResult ~= true then
+		MediaWikiUtils.tracef('UploadFailed: Upload failed: %s.', uploadResult)
 		return LOC("$$$/LrMediaWiki/Interface/UploadFailed=Upload failed: ^1", uploadResult)
 	end
 	return nil


### PR DESCRIPTION
The log file is a good artifact to share when looking into issues during the workflow. Sadly it does not contain much information about anything that went wrong.

I added a few more lines to forward errors to the log file.

Triggered by a discussion on https://de.wikipedia.org/wiki/Wikipedia:Reparatursommer#LrMediaWiki-Plugin